### PR TITLE
removed any overlapping/redundant middle-ware

### DIFF
--- a/app/backend/express-server.js
+++ b/app/backend/express-server.js
@@ -76,10 +76,7 @@ const initExpresss = (options = {}) => {
   );
 
   // lusca
-  expressServer.use(lusca.xframe('SAMEORIGIN'));
   expressServer.use(lusca.p3p('ABCDEF'));
-  expressServer.use(lusca.xssProtection(true));
-  expressServer.use(lusca.nosniff());
   expressServer.use(lusca.referrerPolicy('same-origin'));
 
   // At a minimum, disable X-Powered-By header


### PR DESCRIPTION
Lusca and Helmet have some overlapping functionality, we don't need to run both. Helmet was kept for the ones that were overlapping as they seem to have less issues.