### PR TITLE
chore: all online store questions on one page

### DIFF
--- a/app/components/form/Select.js
+++ b/app/components/form/Select.js
@@ -2,8 +2,10 @@ import Form from 'react-bootstrap/Form';
 import SemanticStyleLabel from 'components/form/SemanticStyleLabel';
 
 const NamedSelect = props => {
-  const { name, title } = props.schema;
-  const { value, onChange, required } = props;
+  const { value, onChange, required, schema } = props;
+  const { name, title } = schema;
+  const enumItems = schema.enum || ['', ...schema.items.enum];
+
   return (
     <Form.Group contollId={`id_${name}`}>
       <SemanticStyleLabel required={required}>{title}</SemanticStyleLabel>
@@ -11,12 +13,13 @@ const NamedSelect = props => {
         as="select"
         required={required}
         name={name}
+        defaultValue=""
         onChange={e => {
           onChange(e.target.value);
         }}
         value={value || ''}
       >
-        {props.schema.enum.map(title => (
+        {enumItems.map(title => (
           <option value={title} key={title}>
             {title}
           </option>

--- a/app/schemas/consolidated-schema.js
+++ b/app/schemas/consolidated-schema.js
@@ -31,7 +31,6 @@ const schema = {
     'madeInBc',
     'employees',
     'importExportBusiness',
-    'existingOnlineStore',
     'canMeetDeadline',
     'otherCovidFunding',
     'sector',
@@ -95,21 +94,6 @@ const schema = {
             madeInBc: { enum: [false] },
           },
           required: ['productionLocation'],
-        },
-      ],
-    },
-    existingOnlineStore: {
-      oneOf: [
-        {
-          properties: {
-            existingOnlineStore: { enum: [false] },
-          },
-        },
-        {
-          properties: {
-            existingOnlineStore: { enum: [true] },
-          },
-          required: ['onlineStoreUrl', 'existingStoreFeatures'],
         },
       ],
     },
@@ -321,34 +305,58 @@ const schema = {
       title: 'Is the business an import/export business?',
       name: 'importExportBusiness',
     },
-    // Has condition, plus a second condition not done yet
-    existingOnlineStore: {
-      type: 'boolean',
-      title: 'Does the business currently have an online store?',
-      name: 'existingOnlineStore',
-    },
-    onlineStoreUrl: {
-      type: 'string',
-      title: 'Link to online store',
-      name: 'onlineStoreUrl',
-      minLength: REQUIRED_TEXT_MIN_LENGTH,
-      maxLength: TEXT_MAX_LENGTH,
-    },
-    existingStoreFeatures: {
-      type: 'array',
-      title: 'If the business has an existing online store, please select all that apply',
-      name: 'existingStoreFeatures',
-      items: {
-        type: 'string',
-        enum: [
-          'Customer registration and information security features',
-          'Shopping cart and order management capabilities',
-          'Payment processing options including application of appropriate taxes and shipping costs at time of ordering',
-          'Product catalogue, search and inventory status',
-          'Website analytics and reporting capabilities',
-        ],
+    onlineStore: {
+      type: 'object',
+      name: 'onlineStore',
+      title: '',
+      properties: {
+        existingOnlineStore: {
+          type: 'boolean',
+          title: 'Does the business currently have an online store?',
+          name: 'existingOnlineStore',
+        },
+        onlineStoreUrl: {
+          type: 'string',
+          title: 'Link to online store',
+          name: 'onlineStoreUrl',
+          minLength: REQUIRED_TEXT_MIN_LENGTH,
+          maxLength: TEXT_MAX_LENGTH,
+        },
+        existingStoreFeatures: {
+          type: 'array',
+          title: 'If the business has an existing online store, please select all that apply',
+          name: 'existingStoreFeatures',
+          items: {
+            type: 'string',
+            enum: [
+              'Customer registration and information security features',
+              'Shopping cart and order management capabilities',
+              'Payment processing options including application of appropriate taxes and shipping costs at time of ordering',
+              'Product catalogue, search and inventory status',
+              'Website analytics and reporting capabilities',
+            ],
+          },
+          uniqueItems: true,
+        },
       },
-      uniqueItems: true,
+      required: ['existingOnlineStore'],
+      dependencies: {
+        existingOnlineStore: {
+          oneOf: [
+            {
+              properties: {
+                existingOnlineStore: { enum: [false] },
+              },
+            },
+            {
+              properties: {
+                existingOnlineStore: { enum: [true] },
+              },
+              required: ['onlineStoreUrl'],
+            },
+          ],
+        },
+      },
     },
     canMeetDeadline: {
       type: 'boolean',

--- a/app/schemas/ui-schema.js
+++ b/app/schemas/ui-schema.js
@@ -31,14 +31,19 @@ const uiSchema = {
   productionLocation: {
     'ui:help': 'This field is required if answering No',
   },
-  onlineStoreUrl: {
-    'ui:help': 'This field is required if answering Yes',
-  },
-  otherPrograms: {
-    'ui:help': 'This field is required if answering Yes',
-  },
-  existingStoreFeatures: {
-    'ui:widget': 'checkboxes',
+  onlineStore: {
+    existingOnlineStore: {
+      'ui:widget': 'radio',
+    },
+    onlineStoreUrl: {
+      'ui:help': 'This field is required if answering Yes',
+    },
+    otherPrograms: {
+      'ui:help': 'This field is required if answering Yes',
+    },
+    existingStoreFeatures: {
+      'ui:widget': 'checkboxes',
+    },
   },
   costs: {
     'ui:FieldTemplate': CostsFieldTemplate,
@@ -83,6 +88,7 @@ const uiSchema = {
     'productionLocation',
     'employees',
     'importExportBusiness',
+    'onlineStore',
     'existingOnlineStore',
     'onlineStoreUrl',
     'existingStoreFeatures',


### PR DESCRIPTION
Put all of the questions about the existing online store onto one page.

When I nested the checkboxes for existingOnlineStoreFeatures it also nested the enum list when inside the select component. So the changes there are just to handle both places the list can end up.

I moved the onlineStore related dependency to its subschema.

The ui:widget: radio for existingOnlineStore had to be hardcoded because it needs to be inside its parents tag, and handling that logic in the booleanFields logic causes the other properties in uiSchema.costs to be lost.

Lastly I finished fixing the view. Just wanted the new structure before I did the actual testing so there is some unrelated cleanup in `views`.

OSF-53