### PR TITLE
chore: handle empty number fields

### DIFF
--- a/app/schemas/consolidated-schema.js
+++ b/app/schemas/consolidated-schema.js
@@ -390,19 +390,19 @@ const schema = {
       title: '',
       properties: {
         serviceProviderCosts: {
-          type: 'string',
+          type: 'number',
           title: 'Service Provider(s)',
           name: 'serviceProviderCosts',
           pattern: CURRENCY_REGEX,
         },
         customerAcquisitionCosts: {
-          type: 'string',
+          type: 'number',
           title: 'Digital Customer Acquisition',
           name: 'customerAcquisitionCosts',
           pattern: CURRENCY_REGEX,
         },
         staffTrainingCosts: {
-          type: 'string',
+          type: 'number',
           title: 'Staff Training Costs',
           name: 'staffTrainingCosts',
           pattern: CURRENCY_REGEX,

--- a/app/utils/form-helpers.js
+++ b/app/utils/form-helpers.js
@@ -74,7 +74,10 @@ export function matchPostBody(postData, schema) {
         newValue = getBooleanValue(newValue);
       } else if (properties[owningPropertyName].properties[propertyName].type === 'array') {
         newValue = getArrayValue(newValue);
-        console.log(`NEW VALUE: `, newValue);
+      }
+      // handles when empty string is passed (user didn't enter)
+      else if (properties[owningPropertyName].properties[propertyName].type === 'number') {
+        newValue = Number(newValue);
       }
 
       if (!formattedData[owningPropertyName]) {


### PR DESCRIPTION
When the costs fields were left empty, no js was throwing an error on them because they were passing ''