### PR TITLE
chore: drop view at beginning of views.sql

### DIFF
--- a/db/sql/views.sql
+++ b/db/sql/views.sql
@@ -1,4 +1,5 @@
-create or replace view public.application_extract
+drop view public.application_extract;
+create view public.application_extract
     as select
         id,
         form_data ->> 'businessName' AS business_name,
@@ -49,4 +50,4 @@ create or replace view public.application_extract
             (form_data -> 'costs' ->> 'staffTrainingCosts')::numeric
           ))
         ) AS grant_request
-    from applications
+    from applications;


### PR DESCRIPTION
PSQL's create or replace doesn't handle dropping columns / changing their names or order. If it tries to, it errors and we don't get the view. Dropping the view before creating it bypasses this problem.