### PR TITLE
chore: validaiton error handles nested fields

### DIFF
--- a/app/pages/api/apply/[page].js
+++ b/app/pages/api/apply/[page].js
@@ -17,7 +17,7 @@ async function handler(req, res) {
   const clearedPostData = matchPostBody(postData, currentPageSchema);
   const newFormData = { ...clearedFormData, ...clearedPostData };
   session.formData = newFormData;
-  console.log('Cleaned newData is: ', newFormData);
+  // console.log('Cleaned newData is: ', newFormData);
 
   const context = { req, newData: newFormData, page, js };
 

--- a/app/pages/message/validation-error.js
+++ b/app/pages/message/validation-error.js
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { HUGE_FONT, MIN_PADDING } from 'theme';
 import StyledP from 'components/StyledP';
 import { validateFormData } from 'services/application';
+import { childParentRelationships } from 'schemas/consolidated-schema';
 import pageSchemas from 'schemas/page-schemas';
 import HrefLink from 'components/HrefLink';
 import startCase from 'lodash/startCase';
@@ -37,6 +38,14 @@ const SuccessBanner = styled.div`
 `;
 
 const findFieldIndex = fieldname => pageSchemas.findIndex(schema => !!schema.properties[fieldname]);
+function findFieldPage(fieldName) {
+  const index = findFieldIndex(fieldName);
+  if (index >= 0) {
+    return index + 1;
+  }
+  const parentName = childParentRelationships[fieldName];
+  return findFieldIndex(parentName) + 1;
+}
 
 export default function ErrorPage({ result }) {
   const { errors } = result;
@@ -47,7 +56,7 @@ export default function ErrorPage({ result }) {
     (ret, err) => {
       if (err.stack.includes(':')) {
         const field = err.stack.split(':')[0];
-        ret[field] = findFieldIndex(field) + 1;
+        ret[field] = findFieldPage(field);
       }
 
       return ret;

--- a/app/schemas/consolidated-schema.js
+++ b/app/schemas/consolidated-schema.js
@@ -432,4 +432,17 @@ const schema = {
   ObjectFieldTemplate,
 };
 
+function getChildParentRelationships(schema) {
+  const rel = {};
+  Object.keys(schema.properties).forEach(field => {
+    if (schema.properties[field].type === 'object') {
+      Object.keys(schema.properties[field].properties).forEach(nestedField => {
+        rel[nestedField] = field;
+      });
+    }
+  });
+  return rel;
+}
+export const childParentRelationships = getChildParentRelationships(schema);
+
 export default schema;


### PR DESCRIPTION
Validation error was showing page 0 for nested fields so the link didn't work.
consolidated-schema to generate child parent relationships for an easier way to find nested fields parents.
it exports the result as childParentRelationships and looks like:
{
  existingOnlineStore: 'onlineStore',
  onlineStoreUrl: 'onlineStore',
  existingStoreFeatures: 'onlineStore',
  serviceProviderCosts: 'costs',
  customerAcquisitionCosts: 'costs',
  staffTrainingCosts: 'costs'
}