### PR TITLE
chore: fix empty costs problem in view

### DIFF
--- a/db/sql/views.sql
+++ b/db/sql/views.sql
@@ -45,9 +45,9 @@ create view public.application_extract
         LEAST(
           7500,
           (.75 * (
-            (form_data -> 'costs' ->> 'serviceProviderCosts')::numeric +
-            (form_data -> 'costs' ->> 'customerAcquisitionCosts')::numeric +
-            (form_data -> 'costs' ->> 'staffTrainingCosts')::numeric
+            GREATEST((form_data -> 'costs' ->> 'serviceProviderCosts')::numeric, 0) +
+            GREATEST((form_data -> 'costs' ->> 'customerAcquisitionCosts')::numeric, 0) +
+            GREATEST((form_data -> 'costs' ->> 'staffTrainingCosts')::numeric, 0)
           ))
         ) AS grant_request
     from applications;


### PR DESCRIPTION
When costs come in null, PSQL LEAST(number, null) will return the number. So if someone didn't enter
all costs fields, grant esitmate was coming back wrong.